### PR TITLE
A quick fix for delayed startup issue.

### DIFF
--- a/aria2/perp/aria2/rc.main
+++ b/aria2/perp/aria2/rc.main
@@ -1,10 +1,22 @@
 #!/bin/sh
-Aria2_enable=`dbus get aria2_enable`
+
 exec 2>&1
+
+Aria2_enable=`dbus get aria2_enable`
+Aria2_restart=`dbus get aria2_restart`
+Aria2_sleep=`dbus get aria2_sleep`
+
 if test ${1} = 'start' ; then
   if [ "$Aria2_enable" == "1" ];then
-   exec /koolshare/aria2/aria2c --conf-path=/koolshare/aria2/aria2.conf
+    if [ "$Aria2_restart" == "1" ]; then
+      echo "Aria2 restart flag detected, it will now be reset"
+      dbus set aria2_restart=0
+    elif [ "$Aria2_sleep" -gt 0 ]; then
+      echo "Awaiting $Aria2_sleep seconds before launching aria2..."
+      sleep $Aria2_sleep
+    fi
+    exec /koolshare/aria2/aria2c --conf-path=/koolshare/aria2/aria2.conf
   fi
 fi
-  
+
 exit 0

--- a/aria2/webs/Module_aria2.asp
+++ b/aria2/webs/Module_aria2.asp
@@ -1037,6 +1037,7 @@ function toggle_func(){
    <input type="hidden" name="SystemCmd" id="SystemCmd" onkeydown="onSubmitCtrl(this, ' Refresh ')" value="aria2_config.sh" />
    <input type="hidden" name="firmver" value="<% nvram_get(" firmver "); %>"/>
    <input type="hidden" id="aria2_enable" name="aria2_enable" value='<% dbus_get_def("aria2_enable", "0"); %>' />
+   <input type="hidden" id="aria2_restart" name="aria2_restart" value="1" />
    <table class="content" align="center" cellpadding="0" cellspacing="0">
     <tr>
      <td width="17">&nbsp;</td>


### PR DESCRIPTION
软件中心 aria2 配置页面上“启动延迟”一项是无效的，小改一下让它生效吧。
否则，万一 USB 挂载慢了一点，aria2 先启动了，就给下载到 jffs 分区或者 tmpfs 里面去，然后就杯具了。